### PR TITLE
Fix for nullable variables

### DIFF
--- a/Model/GooglePlace.php
+++ b/Model/GooglePlace.php
@@ -194,7 +194,7 @@ final class GooglePlace extends Address
     /**
      * @return PlusCode|null
      */
-    public function getPlusCode(): PlusCode
+    public function getPlusCode(): ?PlusCode
     {
         return $this->plusCode;
     }
@@ -210,7 +210,7 @@ final class GooglePlace extends Address
     /**
      * @return Photo[]|null
      */
-    public function getPhotos(): array
+    public function getPhotos(): ?array
     {
         return $this->photos;
     }
@@ -234,7 +234,7 @@ final class GooglePlace extends Address
      *
      * @return int|null
      */
-    public function getPriceLevel(): int
+    public function getPriceLevel(): ?int
     {
         return $this->priceLevel;
     }
@@ -250,7 +250,7 @@ final class GooglePlace extends Address
     /**
      * @return float|null
      */
-    public function getRating(): float
+    public function getRating(): ?float
     {
         return $this->rating;
     }

--- a/Model/PlusCode.php
+++ b/Model/PlusCode.php
@@ -31,7 +31,7 @@ class PlusCode
      * @param string $globalCode
      * @param string $compoundCode
      */
-    public function __construct(string $globalCode, string $compoundCode)
+    public function __construct(string $globalCode = null, string $compoundCode = null)
     {
         $this->globalCode = $globalCode;
         $this->compoundCode = $compoundCode;
@@ -40,7 +40,7 @@ class PlusCode
     /**
      * @return string
      */
-    public function getGlobalCode(): string
+    public function getGlobalCode(): ?string
     {
         return $this->globalCode;
     }
@@ -48,7 +48,7 @@ class PlusCode
     /**
      * @return string
      */
-    public function getCompoundCode(): string
+    public function getCompoundCode(): ?string
     {
         return $this->compoundCode;
     }


### PR DESCRIPTION
Currently if you make a call to geolocate an address with google places and retrieve all of the locations data, if the Photo's return null and are on php 7.3 you will get an error like - 

    "Return value of Geocoder\Provider\Google Maps Places\Model\GooglePlace::getPhotos() must be of the type array"

Simply adding a ? before the strict return means it can actually return a null and not return an error then.  I went through the classes and made sure all were appropriate where null may be provided from my testing.