### PR TITLE
fix + support both reverse modes: Search & Nearby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 phpunit.xml
+.cached_responses/

--- a/GoogleMapsPlaces.php
+++ b/GoogleMapsPlaces.php
@@ -65,6 +65,11 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
     /**
      * @var string
      */
+    const GEOCODE_MODE_NEARBY = 'nearby';
+
+    /**
+     * @var string
+     */
     const DEFAULT_GEOCODE_MODE = self::GEOCODE_MODE_FIND;
 
     /**
@@ -110,7 +115,7 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
             return $this->fetchUrl(self::SEARCH_ENDPOINT_URL_SSL, $this->buildPlaceSearchQuery($query));
         }
 
-        throw new InvalidArgument('Mode must be one of `%s, %s`', self::GEOCODE_MODE_FIND, self::GEOCODE_MODE_SEARCH);
+        throw new InvalidArgument(sprintf('Mode must be one of `%s, %s`', self::GEOCODE_MODE_FIND, self::GEOCODE_MODE_SEARCH));
     }
 
     /**
@@ -122,7 +127,13 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
      */
     public function reverseQuery(ReverseQuery $query): Collection
     {
-        return $this->fetchUrl(self::SEARCH_ENDPOINT_URL_SSL, $this->buildNearbySearchQuery($query));
+        // for backward compatibility: use SEARCH as default mode (includes formatted_address)
+        if (self::GEOCODE_MODE_SEARCH === $query->getData('mode', self::GEOCODE_MODE_SEARCH)) {
+            $url = self::SEARCH_ENDPOINT_URL_SSL;
+        } else {
+            $url = self::NEARBY_ENDPOINT_URL_SSL;
+        }
+        return $this->fetchUrl($url, $this->buildNearbySearchQuery($query));
     }
 
     /**
@@ -212,20 +223,23 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
      */
     private function buildNearbySearchQuery(ReverseQuery $reverseQuery): array
     {
+        // for backward compatibility: use SEARCH as default mode (includes formatted_address)
+        $mode = $reverseQuery->getData('mode', self::GEOCODE_MODE_SEARCH);
+
         $query = [
             'location' => sprintf(
                 '%s,%s',
                 $reverseQuery->getCoordinates()->getLatitude(),
                 $reverseQuery->getCoordinates()->getLongitude()
             ),
-            'rankby' => 'distance',
+            'rankby' => 'prominence',
         ];
 
         if (null !== $reverseQuery->getLocale()) {
             $query['language'] = $reverseQuery->getLocale();
         }
 
-        $query = $this->applyDataFromQuery($reverseQuery, $query, [
+        $validParameters = [
             'keyword',
             'type',
             'name',
@@ -233,14 +247,39 @@ final class GoogleMapsPlaces extends AbstractHttpProvider implements Provider
             'maxprice',
             'name',
             'opennow',
-        ]);
+            'radius',
+        ];
 
-        $requiredParameters = array_filter(array_keys($query), function (string $key) {
-            return in_array($key, ['keyword', 'type', 'name'], true);
-        });
+        if (self::GEOCODE_MODE_NEARBY === $mode) {
+            $validParameters[] = 'rankby';
+        }
 
-        if (1 !== count($requiredParameters)) {
-            throw new InvalidArgument('One of `type`, `keyword`, `name` is required to be set in the Query data for Reverse Geocoding');
+        $query = $this->applyDataFromQuery($reverseQuery, $query, $validParameters);
+
+        if (self::GEOCODE_MODE_NEARBY === $mode) {
+            // mode:nearby, rankby:prominence, parameter:radius
+            if ('prominence' === $query['rankby'] && !isset($query['radius'])) {
+                throw new InvalidArgument('`radius` is required to be set in the Query data for Reverse Geocoding when ranking by prominence');
+            }
+
+            // mode:nearby, rankby:distance, parameter:type/keyword/name
+            if ('distance' === $query['rankby']) {
+                if (isset($query['radius'])) unset($query['radius']);
+    
+                $requiredParameters = array_intersect(['keyword', 'type', 'name'], array_keys($query));
+
+                if (1 !== count($requiredParameters)) {
+                    throw new InvalidArgument('One of `type`, `keyword`, `name` is required to be set in the Query data for Reverse Geocoding when ranking by distance');
+                }
+            }
+        }
+
+        if (self::GEOCODE_MODE_SEARCH === $mode) {
+            // mode:search, parameter:type
+
+            if (!isset($query['type'])) {
+                throw new InvalidArgument('`type` is required to be set in the Query data for Reverse Geocoding when using search mode');
+            }
         }
 
         return $query;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Maps Geocoder provider
+# Google Places Geocoder provider
 [![Build Status](https://travis-ci.org/geocoder-php/google-maps-places-provider.svg?branch=master)](http://travis-ci.org/geocoder-php/google-maps-places-provider)
 [![Latest Stable Version](https://poser.pugx.org/geocoder-php/google-maps-places-provider/v/stable)](https://packagist.org/packages/geocoder-php/google-maps-places-provider)
 [![Total Downloads](https://poser.pugx.org/geocoder-php/google-maps-places-provider/downloads)](https://packagist.org/packages/geocoder-php/google-maps-places-provider)
@@ -7,7 +7,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/geocoder-php/google-maps-places-provider.svg?style=flat-square)](https://scrutinizer-ci.com/g/geocoder-php/google-maps-places-provider)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 
-This is the Google Maps Places provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
+This is the Google Places provider from the PHP Geocoder. This is a **READ ONLY** repository. See the
 [main repo](https://github.com/geocoder-php/Geocoder) for information and documentation. 
 
 ## Install
@@ -20,7 +20,8 @@ composer require geocoder-php/google-maps-places-provider
 https://developers.google.com/places/web-service
 
 ## Usage
-This provider often requires extra data when making queries, due to requirements of the underlying places API.
+
+This provider often requires extra data when making queries, due to requirements of the underlying Places API.
 
 ### Geocoding
 This provider supports two different modes of geocoding by text.
@@ -33,6 +34,24 @@ This mode will perform a search based on the input text.
 It's a lot more forgiving that the `find` mode, but results will contain all fields and thus be billed at the highest rate.
 
 ```php
+$results = $provider->geocodeQuery(
+    GeocodeQuery::create('bar in sydney')
+        ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_SEARCH)
+);
+```
+
+around location:
+
+```php
+$results = $provider->geocodeQuery(
+    GeocodeQuery::create('bar')
+        ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_SEARCH)
+        ->withData('location', '-32.926642, 151.783026')
+);
+```
+
+
+```php
 $findResults = $provider->geocodeQuery(GeocodeQuery::create('Museum of Contemporary Art Australia')); // One Result
 
 $searchResults = $provider->geocodeQuery(GeocodeQuery::create('art museum sydney'))
@@ -40,12 +59,48 @@ $searchResults = $provider->geocodeQuery(GeocodeQuery::create('art museum sydney
 ```
 
 ### Reverse Geocoding
-When reverse geocoding, you are required to supply either a `keyword`, `type` or `name`.
-See https://developers.google.com/places/web-service/search#PlaceSearchRequests
+
+Three options available for reverse geocoding of latlon coordinates:
+
+- mode `search` + type (e.g.) `bar`: uses Google Place API [Text search](https://developers.google.com/places/web-service/search#TextSearchRequests), requires `type` - note: is similar to search around location
+- mode `nearby` + rankby `distance`: uses Google Place API [Nearby search](https://developers.google.com/places/web-service/search#PlaceSearchRequests), requires `type/keyword/name`
+- mode `nearby` + rankby `prominence`: uses Google Place API [Nearby search](https://developers.google.com/places/web-service/search#PlaceSearchRequests), requires `radius`
+
+Defaults: mode `search`, rankby `prominence` (for mode `nearby`).
+Mode `search` gives formatted_address, mode `nearby` gives vicinity instead.  
+Similar but not the same. E.g.
+
+- `search`: "formatted_address": "7 Cope St, Redfern NSW 2016"
+- `nearby`: "vicinity": "7 Cope Street, Redfern"
+
+Examples
 
 ```php
-$results = $provider->reverseQuery(ReverseQuery::fromCoordinates(-33.892674, 151.200727)->withData('type', 'bar'));
+$results = $provider->reverseQuery(
+    ReverseQuery::fromCoordinates(-33.892674, 151.200727)
+        ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_NEARBY)
+        //->withData('rankby','prominence'); // =default
+        ->withData('radius', 500)
+    );
 ```
+
+```php
+$results = $provider->reverseQuery(
+    ReverseQuery::fromCoordinates(-33.892674, 151.200727)
+        // ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_SEARCH) // =default
+        ->withData('type', 'bar')
+    );
+```
+
+```php
+$results = $provider->reverseQuery(
+    ReverseQuery::fromCoordinates(-33.892674, 151.200727)
+        ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_NEARBY)
+        ->withData('rankby','distance');
+        ->withData('type', 'bar')
+    );
+```
+
 
 ### Contribute
 


### PR DESCRIPTION
Coming from https://github.com/geocoder-php/Geocoder/issues/1063

The reverse query was using `Search` (requires Type). 
This PR adds support for `Nearby`, which can be used with:
rankby:prominence + radius (=default `Nearby` combination)
rankby:distance + type/keyword/name (distance + type is very similar to the original `Search`)

Note: `Search` returns formatted_address, `Nearby` returns vicinity.