### PR TITLE
Allow getRating to return null

### DIFF
--- a/Model/GooglePlace.php
+++ b/Model/GooglePlace.php
@@ -276,7 +276,7 @@ final class GooglePlace extends Address
     /**
      * @return float|null
      */
-    public function getRating(): float
+    public function getRating(): ?float
     {
         return $this->rating;
     }


### PR DESCRIPTION
The `getRating()` return signature is not according to the documentation. 
This change would fix this.